### PR TITLE
feat(Provider): use asset hash as versionId

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,6 +4,8 @@
 
 ### SopsSecret <a name="SopsSecret" id="cdk-sops-secrets.SopsSecret"></a>
 
+- *Implements:* @aws-cdk/aws-secretsmanager.ISecret
+
 A drop in replacement for the normal Secret, that is populated with the encrypted content of the given sops file.
 
 #### Initializers <a name="Initializers" id="cdk-sops-secrets.SopsSecret.Initializer"></a>
@@ -45,12 +47,11 @@ new SopsSecret(scope: Construct, id: string, props: SopsSecretProps)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-sops-secrets.SopsSecret.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdk-sops-secrets.SopsSecret.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
-| <code><a href="#cdk-sops-secrets.SopsSecret.addReplicaRegion">addReplicaRegion</a></code> | Adds a replica region for the secret. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.addRotationSchedule">addRotationSchedule</a></code> | Adds a rotation schedule to the secret. |
-| <code><a href="#cdk-sops-secrets.SopsSecret.addTargetAttachment">addTargetAttachment</a></code> | Adds a target attachment to the secret. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.addToResourcePolicy">addToResourcePolicy</a></code> | Adds a statement to the IAM resource policy associated with this secret. |
+| <code><a href="#cdk-sops-secrets.SopsSecret.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.attach">attach</a></code> | Attach a target to this secret. |
+| <code><a href="#cdk-sops-secrets.SopsSecret.currentVersionId">currentVersionId</a></code> | Returns the current versionId that was created via the SopsSync. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.denyAccountRootDelete">denyAccountRootDelete</a></code> | Denies the `DeleteSecret` action to all principals within the current account. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.grantRead">grantRead</a></code> | Grants reading the secret value to some role. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.grantWrite">grantWrite</a></code> | Grants writing and updating the secret value to some role. |
@@ -65,6 +66,44 @@ public toString(): string
 ```
 
 Returns a string representation of this construct.
+
+##### `addRotationSchedule` <a name="addRotationSchedule" id="cdk-sops-secrets.SopsSecret.addRotationSchedule"></a>
+
+```typescript
+public addRotationSchedule(id: string, options: RotationScheduleOptions): RotationSchedule
+```
+
+Adds a rotation schedule to the secret.
+
+###### `id`<sup>Required</sup> <a name="id" id="cdk-sops-secrets.SopsSecret.addRotationSchedule.parameter.id"></a>
+
+- *Type:* string
+
+---
+
+###### `options`<sup>Required</sup> <a name="options" id="cdk-sops-secrets.SopsSecret.addRotationSchedule.parameter.options"></a>
+
+- *Type:* @aws-cdk/aws-secretsmanager.RotationScheduleOptions
+
+---
+
+##### `addToResourcePolicy` <a name="addToResourcePolicy" id="cdk-sops-secrets.SopsSecret.addToResourcePolicy"></a>
+
+```typescript
+public addToResourcePolicy(statement: PolicyStatement): AddToResourcePolicyResult
+```
+
+Adds a statement to the IAM resource policy associated with this secret.
+
+If this secret was created in this stack, a resource policy will be
+automatically created upon the first call to `addToResourcePolicy`. If
+the secret is imported, then this is a no-op.
+
+###### `statement`<sup>Required</sup> <a name="statement" id="cdk-sops-secrets.SopsSecret.addToResourcePolicy.parameter.statement"></a>
+
+- *Type:* @aws-cdk/aws-iam.PolicyStatement
+
+---
 
 ##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="cdk-sops-secrets.SopsSecret.applyRemovalPolicy"></a>
 
@@ -88,88 +127,6 @@ account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
 
 ---
 
-##### `addReplicaRegion` <a name="addReplicaRegion" id="cdk-sops-secrets.SopsSecret.addReplicaRegion"></a>
-
-```typescript
-public addReplicaRegion(region: string, encryptionKey?: IKey): void
-```
-
-Adds a replica region for the secret.
-
-###### `region`<sup>Required</sup> <a name="region" id="cdk-sops-secrets.SopsSecret.addReplicaRegion.parameter.region"></a>
-
-- *Type:* string
-
-The name of the region.
-
----
-
-###### `encryptionKey`<sup>Optional</sup> <a name="encryptionKey" id="cdk-sops-secrets.SopsSecret.addReplicaRegion.parameter.encryptionKey"></a>
-
-- *Type:* @aws-cdk/aws-kms.IKey
-
-The customer-managed encryption key to use for encrypting the secret value.
-
----
-
-##### `addRotationSchedule` <a name="addRotationSchedule" id="cdk-sops-secrets.SopsSecret.addRotationSchedule"></a>
-
-```typescript
-public addRotationSchedule(id: string, options: RotationScheduleOptions): RotationSchedule
-```
-
-Adds a rotation schedule to the secret.
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-sops-secrets.SopsSecret.addRotationSchedule.parameter.id"></a>
-
-- *Type:* string
-
----
-
-###### `options`<sup>Required</sup> <a name="options" id="cdk-sops-secrets.SopsSecret.addRotationSchedule.parameter.options"></a>
-
-- *Type:* @aws-cdk/aws-secretsmanager.RotationScheduleOptions
-
----
-
-##### ~~`addTargetAttachment`~~ <a name="addTargetAttachment" id="cdk-sops-secrets.SopsSecret.addTargetAttachment"></a>
-
-```typescript
-public addTargetAttachment(id: string, options: AttachedSecretOptions): SecretTargetAttachment
-```
-
-Adds a target attachment to the secret.
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-sops-secrets.SopsSecret.addTargetAttachment.parameter.id"></a>
-
-- *Type:* string
-
----
-
-###### `options`<sup>Required</sup> <a name="options" id="cdk-sops-secrets.SopsSecret.addTargetAttachment.parameter.options"></a>
-
-- *Type:* @aws-cdk/aws-secretsmanager.AttachedSecretOptions
-
----
-
-##### `addToResourcePolicy` <a name="addToResourcePolicy" id="cdk-sops-secrets.SopsSecret.addToResourcePolicy"></a>
-
-```typescript
-public addToResourcePolicy(statement: PolicyStatement): AddToResourcePolicyResult
-```
-
-Adds a statement to the IAM resource policy associated with this secret.
-
-If this secret was created in this stack, a resource policy will be
-automatically created upon the first call to `addToResourcePolicy`. If
-the secret is imported, then this is a no-op.
-
-###### `statement`<sup>Required</sup> <a name="statement" id="cdk-sops-secrets.SopsSecret.addToResourcePolicy.parameter.statement"></a>
-
-- *Type:* @aws-cdk/aws-iam.PolicyStatement
-
----
-
 ##### `attach` <a name="attach" id="cdk-sops-secrets.SopsSecret.attach"></a>
 
 ```typescript
@@ -182,9 +139,15 @@ Attach a target to this secret.
 
 - *Type:* @aws-cdk/aws-secretsmanager.ISecretAttachmentTarget
 
-The target to attach.
-
 ---
+
+##### `currentVersionId` <a name="currentVersionId" id="cdk-sops-secrets.SopsSecret.currentVersionId"></a>
+
+```typescript
+public currentVersionId(): string
+```
+
+Returns the current versionId that was created via the SopsSync.
 
 ##### `denyAccountRootDelete` <a name="denyAccountRootDelete" id="cdk-sops-secrets.SopsSecret.denyAccountRootDelete"></a>
 
@@ -247,13 +210,6 @@ Interpret the secret as a JSON object and return a field's value from it as a `S
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-sops-secrets.SopsSecret.isConstruct">isConstruct</a></code> | Return whether the given object is a Construct. |
-| <code><a href="#cdk-sops-secrets.SopsSecret.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
-| <code><a href="#cdk-sops-secrets.SopsSecret.fromSecretArn">fromSecretArn</a></code> | *No description.* |
-| <code><a href="#cdk-sops-secrets.SopsSecret.fromSecretAttributes">fromSecretAttributes</a></code> | Import an existing secret into the Stack. |
-| <code><a href="#cdk-sops-secrets.SopsSecret.fromSecretCompleteArn">fromSecretCompleteArn</a></code> | Imports a secret by complete ARN. |
-| <code><a href="#cdk-sops-secrets.SopsSecret.fromSecretName">fromSecretName</a></code> | Imports a secret by secret name; |
-| <code><a href="#cdk-sops-secrets.SopsSecret.fromSecretNameV2">fromSecretNameV2</a></code> | Imports a secret by secret name. |
-| <code><a href="#cdk-sops-secrets.SopsSecret.fromSecretPartialArn">fromSecretPartialArn</a></code> | Imports a secret by partial ARN. |
 
 ---
 
@@ -273,217 +229,19 @@ Return whether the given object is a Construct.
 
 ---
 
-##### `isResource` <a name="isResource" id="cdk-sops-secrets.SopsSecret.isResource"></a>
-
-```typescript
-import { SopsSecret } from 'cdk-sops-secrets'
-
-SopsSecret.isResource(construct: IConstruct)
-```
-
-Check whether the given construct is a Resource.
-
-###### `construct`<sup>Required</sup> <a name="construct" id="cdk-sops-secrets.SopsSecret.isResource.parameter.construct"></a>
-
-- *Type:* @aws-cdk/core.IConstruct
-
----
-
-##### ~~`fromSecretArn`~~ <a name="fromSecretArn" id="cdk-sops-secrets.SopsSecret.fromSecretArn"></a>
-
-```typescript
-import { SopsSecret } from 'cdk-sops-secrets'
-
-SopsSecret.fromSecretArn(scope: Construct, id: string, secretArn: string)
-```
-
-###### `scope`<sup>Required</sup> <a name="scope" id="cdk-sops-secrets.SopsSecret.fromSecretArn.parameter.scope"></a>
-
-- *Type:* constructs.Construct
-
----
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-sops-secrets.SopsSecret.fromSecretArn.parameter.id"></a>
-
-- *Type:* string
-
----
-
-###### `secretArn`<sup>Required</sup> <a name="secretArn" id="cdk-sops-secrets.SopsSecret.fromSecretArn.parameter.secretArn"></a>
-
-- *Type:* string
-
----
-
-##### `fromSecretAttributes` <a name="fromSecretAttributes" id="cdk-sops-secrets.SopsSecret.fromSecretAttributes"></a>
-
-```typescript
-import { SopsSecret } from 'cdk-sops-secrets'
-
-SopsSecret.fromSecretAttributes(scope: Construct, id: string, attrs: SecretAttributes)
-```
-
-Import an existing secret into the Stack.
-
-###### `scope`<sup>Required</sup> <a name="scope" id="cdk-sops-secrets.SopsSecret.fromSecretAttributes.parameter.scope"></a>
-
-- *Type:* constructs.Construct
-
-the scope of the import.
-
----
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-sops-secrets.SopsSecret.fromSecretAttributes.parameter.id"></a>
-
-- *Type:* string
-
-the ID of the imported Secret in the construct tree.
-
----
-
-###### `attrs`<sup>Required</sup> <a name="attrs" id="cdk-sops-secrets.SopsSecret.fromSecretAttributes.parameter.attrs"></a>
-
-- *Type:* @aws-cdk/aws-secretsmanager.SecretAttributes
-
-the attributes of the imported secret.
-
----
-
-##### `fromSecretCompleteArn` <a name="fromSecretCompleteArn" id="cdk-sops-secrets.SopsSecret.fromSecretCompleteArn"></a>
-
-```typescript
-import { SopsSecret } from 'cdk-sops-secrets'
-
-SopsSecret.fromSecretCompleteArn(scope: Construct, id: string, secretCompleteArn: string)
-```
-
-Imports a secret by complete ARN.
-
-The complete ARN is the ARN with the Secrets Manager-supplied suffix.
-
-###### `scope`<sup>Required</sup> <a name="scope" id="cdk-sops-secrets.SopsSecret.fromSecretCompleteArn.parameter.scope"></a>
-
-- *Type:* constructs.Construct
-
----
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-sops-secrets.SopsSecret.fromSecretCompleteArn.parameter.id"></a>
-
-- *Type:* string
-
----
-
-###### `secretCompleteArn`<sup>Required</sup> <a name="secretCompleteArn" id="cdk-sops-secrets.SopsSecret.fromSecretCompleteArn.parameter.secretCompleteArn"></a>
-
-- *Type:* string
-
----
-
-##### ~~`fromSecretName`~~ <a name="fromSecretName" id="cdk-sops-secrets.SopsSecret.fromSecretName"></a>
-
-```typescript
-import { SopsSecret } from 'cdk-sops-secrets'
-
-SopsSecret.fromSecretName(scope: Construct, id: string, secretName: string)
-```
-
-Imports a secret by secret name;
-
-the ARN of the Secret will be set to the secret name.
-A secret with this name must exist in the same account & region.
-
-###### `scope`<sup>Required</sup> <a name="scope" id="cdk-sops-secrets.SopsSecret.fromSecretName.parameter.scope"></a>
-
-- *Type:* constructs.Construct
-
----
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-sops-secrets.SopsSecret.fromSecretName.parameter.id"></a>
-
-- *Type:* string
-
----
-
-###### `secretName`<sup>Required</sup> <a name="secretName" id="cdk-sops-secrets.SopsSecret.fromSecretName.parameter.secretName"></a>
-
-- *Type:* string
-
----
-
-##### `fromSecretNameV2` <a name="fromSecretNameV2" id="cdk-sops-secrets.SopsSecret.fromSecretNameV2"></a>
-
-```typescript
-import { SopsSecret } from 'cdk-sops-secrets'
-
-SopsSecret.fromSecretNameV2(scope: Construct, id: string, secretName: string)
-```
-
-Imports a secret by secret name.
-
-A secret with this name must exist in the same account & region.
-Replaces the deprecated `fromSecretName`.
-
-###### `scope`<sup>Required</sup> <a name="scope" id="cdk-sops-secrets.SopsSecret.fromSecretNameV2.parameter.scope"></a>
-
-- *Type:* constructs.Construct
-
----
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-sops-secrets.SopsSecret.fromSecretNameV2.parameter.id"></a>
-
-- *Type:* string
-
----
-
-###### `secretName`<sup>Required</sup> <a name="secretName" id="cdk-sops-secrets.SopsSecret.fromSecretNameV2.parameter.secretName"></a>
-
-- *Type:* string
-
----
-
-##### `fromSecretPartialArn` <a name="fromSecretPartialArn" id="cdk-sops-secrets.SopsSecret.fromSecretPartialArn"></a>
-
-```typescript
-import { SopsSecret } from 'cdk-sops-secrets'
-
-SopsSecret.fromSecretPartialArn(scope: Construct, id: string, secretPartialArn: string)
-```
-
-Imports a secret by partial ARN.
-
-The partial ARN is the ARN without the Secrets Manager-supplied suffix.
-
-###### `scope`<sup>Required</sup> <a name="scope" id="cdk-sops-secrets.SopsSecret.fromSecretPartialArn.parameter.scope"></a>
-
-- *Type:* constructs.Construct
-
----
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-sops-secrets.SopsSecret.fromSecretPartialArn.parameter.id"></a>
-
-- *Type:* string
-
----
-
-###### `secretPartialArn`<sup>Required</sup> <a name="secretPartialArn" id="cdk-sops-secrets.SopsSecret.fromSecretPartialArn.parameter.secretPartialArn"></a>
-
-- *Type:* string
-
----
-
 #### Properties <a name="Properties" id="Properties"></a>
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.node">node</a></code> | <code>@aws-cdk/core.ConstructNode</code> | The construct tree node associated with this construct. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.env">env</a></code> | <code>@aws-cdk/core.ResourceEnvironment</code> | The environment this resource belongs to. |
-| <code><a href="#cdk-sops-secrets.SopsSecret.property.stack">stack</a></code> | <code>@aws-cdk/core.Stack</code> | The stack in which this resource is defined. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.secretArn">secretArn</a></code> | <code>string</code> | The ARN of the secret in AWS Secrets Manager. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.secretName">secretName</a></code> | <code>string</code> | The name of the secret. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.secretValue">secretValue</a></code> | <code>@aws-cdk/core.SecretValue</code> | Retrieve the value of the stored secret as a `SecretValue`. |
+| <code><a href="#cdk-sops-secrets.SopsSecret.property.stack">stack</a></code> | <code>@aws-cdk/core.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#cdk-sops-secrets.SopsSecret.property.sync">sync</a></code> | <code><a href="#cdk-sops-secrets.SopsSync">SopsSync</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.encryptionKey">encryptionKey</a></code> | <code>@aws-cdk/aws-kms.IKey</code> | The customer-managed encryption key that is used to encrypt this secret, if any. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.secretFullArn">secretFullArn</a></code> | <code>string</code> | The full ARN of the secret in AWS Secrets Manager, which is the ARN including the Secrets Manager-supplied 6-character suffix. |
-| <code><a href="#cdk-sops-secrets.SopsSecret.property.sync">sync</a></code> | <code><a href="#cdk-sops-secrets.SopsSync">SopsSync</a></code> | *No description.* |
 
 ---
 
@@ -515,18 +273,6 @@ this is always the same as the environment of the stack they belong to;
 however, for imported resources
 (those obtained from static methods like fromRoleArn, fromBucketName, etc.),
 that might be different than the stack they were imported into.
-
----
-
-##### `stack`<sup>Required</sup> <a name="stack" id="cdk-sops-secrets.SopsSecret.property.stack"></a>
-
-```typescript
-public readonly stack: Stack;
-```
-
-- *Type:* @aws-cdk/core.Stack
-
-The stack in which this resource is defined.
 
 ---
 
@@ -572,6 +318,28 @@ Retrieve the value of the stored secret as a `SecretValue`.
 
 ---
 
+##### `stack`<sup>Required</sup> <a name="stack" id="cdk-sops-secrets.SopsSecret.property.stack"></a>
+
+```typescript
+public readonly stack: Stack;
+```
+
+- *Type:* @aws-cdk/core.Stack
+
+The stack in which this resource is defined.
+
+---
+
+##### `sync`<sup>Required</sup> <a name="sync" id="cdk-sops-secrets.SopsSecret.property.sync"></a>
+
+```typescript
+public readonly sync: SopsSync;
+```
+
+- *Type:* <a href="#cdk-sops-secrets.SopsSync">SopsSync</a>
+
+---
+
 ##### `encryptionKey`<sup>Optional</sup> <a name="encryptionKey" id="cdk-sops-secrets.SopsSecret.property.encryptionKey"></a>
 
 ```typescript
@@ -598,16 +366,6 @@ public readonly secretFullArn: string;
 The full ARN of the secret in AWS Secrets Manager, which is the ARN including the Secrets Manager-supplied 6-character suffix.
 
 This is equal to `secretArn` in most cases, but is undefined when a full ARN is not available (e.g., secrets imported by name).
-
----
-
-##### `sync`<sup>Required</sup> <a name="sync" id="cdk-sops-secrets.SopsSecret.property.sync"></a>
-
-```typescript
-public readonly sync: SopsSync;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.SopsSync">SopsSync</a>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,4 +43,7 @@ Other than that, or perhaps more importantly, my goal was to learn new things:
 
 # Other Tools like this
 
-* [sops-secretsmanager-cdk](https://github.com/isotoma/sops-secretsmanager-cdk): Does nearly the same (really, found it after this was already done). Less options than this construct.
+The problem this Construct addresses is so good, already two other implementations exist:
+
+* [isotoma/sops-secretsmanager-cdk](https://github.com/isotoma/sops-secretsmanager-cdk): Does nearly the same. Uses CustomResource, wraps the sops cli, does not support flatten. Found it after I published my solution to npm :-/ 
+* [taimos/secretsmanager-versioning](https://github.com/taimos/secretsmanager-versioning): Different approach on the same problem. This is a cli tool with very nice integration into cdk and also handles git versioning information.

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,0 @@
-module github.com/markussiebert/cdk-sops-secrets
-
-go 1.18
-
-require (
-	cdk-sops-secrets/lambda v0.0.0
-)
-
-replace cdk-sops-secrets/lambda => ./lambda

--- a/lambda/__snapshots__/handler_json_test.snap
+++ b/lambda/__snapshots__/handler_json_test.snap
@@ -10,6 +10,7 @@
 [Test_FullWorkflow_Create_S3_JSON_Simple - 2]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
+  ClientRequestToken: "",
   SecretId: "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
   SecretString: "{\n  \"key1\": \"value1\",\n  \"key2\": 12345,\n  \"key3\": false\n}"
 }
@@ -40,6 +41,7 @@ nil
 [Test_FullWorkflow_Create_S3_JSON_Complex - 2]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
+  ClientRequestToken: "",
   SecretId: "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
   SecretString: "{\n  \"and now\": {\n    \"some\": [\n      {\n        \"basic\": false\n      },\n      {\n        \"nested\": 12345\n      },\n      {\n        \"type\": 1.2345\n      },\n      {\n        \"tests\": \"Finish!\"\n      }\n    ]\n  },\n  \"some\": {\n    \"deep\": {\n      \"nested\": {\n        \"arrays\": [\n          \"with\",\n          \"several\",\n          {\n            \"values\": {\n              \"and\": \"objects\"\n            }\n          }\n        ],\n        \"object\": \"structure\"\n      }\n    },\n    \"notsodeep\": \"struct\"\n  }\n}"
 }
@@ -70,6 +72,7 @@ nil
 [Test_FullWorkflow_Create_S3_JSON_Complex_StringifyValues - 2]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
+  ClientRequestToken: "",
   SecretId: "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
   SecretString: "{\n  \"and now\": {\n    \"some\": [\n      {\n        \"basic\": \"false\"\n      },\n      {\n        \"nested\": \"12345\"\n      },\n      {\n        \"type\": \"1.2345\"\n      },\n      {\n        \"tests\": \"Finish!\"\n      }\n    ]\n  },\n  \"some\": {\n    \"deep\": {\n      \"nested\": {\n        \"arrays\": [\n          \"with\",\n          \"several\",\n          {\n            \"values\": {\n              \"and\": \"objects\"\n            }\n          }\n        ],\n        \"object\": \"structure\"\n      }\n    },\n    \"notsodeep\": \"struct\"\n  }\n}"
 }
@@ -100,6 +103,7 @@ nil
 [Test_FullWorkflow_Create_S3_JSON_Complex_Flat - 2]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
+  ClientRequestToken: "",
   SecretId: "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
   SecretString: "{\n  \"and now.some[0].basic\": false,\n  \"and now.some[1].nested\": 12345,\n  \"and now.some[2].type\": 1.2345,\n  \"and now.some[3].tests\": \"Finish!\",\n  \"some.deep.nested.arrays[0]\": \"with\",\n  \"some.deep.nested.arrays[1]\": \"several\",\n  \"some.deep.nested.arrays[2].values.and\": \"objects\",\n  \"some.deep.nested.object\": \"structure\",\n  \"some.notsodeep\": \"struct\"\n}"
 }

--- a/lambda/__snapshots__/handler_yaml_test.snap
+++ b/lambda/__snapshots__/handler_yaml_test.snap
@@ -10,6 +10,7 @@
 [Test_FullWorkflow_Create_S3_YAML_Simple - 2]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
+  ClientRequestToken: "",
   SecretId: "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
   SecretString: "key1: value1\nkey2: 12345\nkey3: false\n"
 }
@@ -40,6 +41,7 @@ nil
 [Test_FullWorkflow_Create_S3_YAML_as_JSON_Simple - 2]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
+  ClientRequestToken: "",
   SecretId: "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
   SecretString: "{\n  \"key1\": \"value1\",\n  \"key2\": 12345,\n  \"key3\": false\n}"
 }
@@ -70,6 +72,7 @@ nil
 [Test_FullWorkflow_Create_S3_YAML_Complex - 2]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
+  ClientRequestToken: "",
   SecretId: "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
   SecretString: "and now:\n    some:\n        - basic: false\n        - nested: 12345\n        - type: 1.2345\n        - tests: Finish!\nsome:\n    deep:\n        nested:\n            arrays:\n                - with\n                - several\n                - values:\n                    and: objects\n            object: structure\n    notsodeep: struct\n"
 }
@@ -100,6 +103,7 @@ nil
 [Test_FullWorkflow_Create_S3_YAML_as_JSON_Complex - 2]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
+  ClientRequestToken: "",
   SecretId: "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
   SecretString: "{\n  \"and now\": {\n    \"some\": [\n      {\n        \"basic\": false\n      },\n      {\n        \"nested\": 12345\n      },\n      {\n        \"type\": 1.2345\n      },\n      {\n        \"tests\": \"Finish!\"\n      }\n    ]\n  },\n  \"some\": {\n    \"deep\": {\n      \"nested\": {\n        \"arrays\": [\n          \"with\",\n          \"several\",\n          {\n            \"values\": {\n              \"and\": \"objects\"\n            }\n          }\n        ],\n        \"object\": \"structure\"\n      }\n    },\n    \"notsodeep\": \"struct\"\n  }\n}"
 }
@@ -130,6 +134,7 @@ nil
 [Test_FullWorkflow_Create_S3_YAML_Complex_Flat - 2]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
+  ClientRequestToken: "",
   SecretId: "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
   SecretString: "and now.some[0].basic: false\nand now.some[1].nested: 12345\nand now.some[2].type: 1.2345\nand now.some[3].tests: Finish!\nsome.deep.nested.arrays[0]: with\nsome.deep.nested.arrays[1]: several\nsome.deep.nested.arrays[2].values.and: objects\nsome.deep.nested.object: structure\nsome.notsodeep: struct\n"
 }
@@ -160,6 +165,7 @@ nil
 [Test_FullWorkflow_Create_S3_YAML_as_JSON_Complex_Flat - 2]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
+  ClientRequestToken: "",
   SecretId: "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
   SecretString: "{\n  \"and now.some[0].basic\": false,\n  \"and now.some[1].nested\": 12345,\n  \"and now.some[2].type\": 1.2345,\n  \"and now.some[3].tests\": \"Finish!\",\n  \"some.deep.nested.arrays[0]\": \"with\",\n  \"some.deep.nested.arrays[1]\": \"several\",\n  \"some.deep.nested.arrays[2].values.and\": \"objects\",\n  \"some.deep.nested.object\": \"structure\",\n  \"some.notsodeep\": \"struct\"\n}"
 }

--- a/lambda/__snapshots__/main_test.snap
+++ b/lambda/__snapshots__/main_test.snap
@@ -35,7 +35,8 @@
 [Test_UpdateSecret - 1]
 >>>SecretsManagerMockClient.PutSecretValue.Input
 {
-  SecretId: "arn:${Partition}:secretsmanager:${Region}:${Account}:secret:${SecretId}",
+  ClientRequestToken: "4547532a137611d83958d17095c6c2d38ae0036a760c3b79c9dd5957d1c20cf2",
+  SecretId: "arn::secretsmanager:::secret:",
   SecretString: "some-secret-data"
 }
 ---

--- a/lambda/main_test.go
+++ b/lambda/main_test.go
@@ -48,10 +48,11 @@ func Test_UpdateSecret(t *testing.T) {
 			t: t,
 		},
 	}
+	fileName := "4547532a137611d83958d17095c6c2d38ae0036a760c3b79c9dd5957d1c20cf2.yaml"
 	inputArn := "arn:${Partition}:secretsmanager:${Region}:${Account}:secret:${SecretId}"
 	secretValue := []byte("some-secret-data")
 
-	response, err := mocks.updateSecret(inputArn, secretValue)
+	response, err := mocks.updateSecret(fileName, inputArn, secretValue)
 	check(err)
 
 	snaps.MatchSnapshot(t, response)

--- a/test/secret.integ.snapshot/SecretIntegration.assets.json
+++ b/test/secret.integ.snapshot/SecretIntegration.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "16.0.0",
   "files": {
-    "934edcf6115b2213914d0b909d6a57615b77497bc80e31d20eff033244b10a83": {
+    "8bcfb9be629c18f572586234ab20394a37fd422dc1fb7657730fadbbdf69bc36": {
       "source": {
-        "path": "asset.934edcf6115b2213914d0b909d6a57615b77497bc80e31d20eff033244b10a83.zip",
+        "path": "asset.8bcfb9be629c18f572586234ab20394a37fd422dc1fb7657730fadbbdf69bc36.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "934edcf6115b2213914d0b909d6a57615b77497bc80e31d20eff033244b10a83.zip",
+          "objectKey": "8bcfb9be629c18f572586234ab20394a37fd422dc1fb7657730fadbbdf69bc36.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -66,7 +66,7 @@
         }
       }
     },
-    "e2df3958ec05e41000a474e751c6beafa915cb92a2b6d699f4ceefdde98d611d": {
+    "06aa81c8f1b4bd04a11046c7287961ffe7a7a9372052cf5d65223b1e90e04266": {
       "source": {
         "path": "SecretIntegration.template.json",
         "packaging": "file"
@@ -74,7 +74,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e2df3958ec05e41000a474e751c6beafa915cb92a2b6d699f4ceefdde98d611d.json",
+          "objectKey": "06aa81c8f1b4bd04a11046c7287961ffe7a7a9372052cf5d65223b1e90e04266.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret.integ.snapshot/SecretIntegration.template.json
+++ b/test/secret.integ.snapshot/SecretIntegration.template.json
@@ -1,6 +1,6 @@
 {
   "Resources": {
-    "SopsSecretJSON9B18C923": {
+    "SopsSecretJSON72040543": {
       "Type": "AWS::SecretsManager::Secret",
       "Properties": {
         "GenerateSecretString": {}
@@ -18,7 +18,7 @@
           ]
         },
         "SecretARN": {
-          "Ref": "SopsSecretJSON9B18C923"
+          "Ref": "SopsSecretJSON72040543"
         },
         "SopsS3File": {
           "Bucket": {
@@ -77,7 +77,7 @@
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SopsSecretJSON9B18C923"
+                "Ref": "SopsSecretJSON72040543"
               }
             },
             {
@@ -128,7 +128,7 @@
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SopsSecretYAML311046EA"
+                "Ref": "SopsSecretYAMLC392F558"
               }
             },
             {
@@ -138,7 +138,7 @@
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SopsSecretYAMLasJSONE90622C5"
+                "Ref": "SopsSecretYAMLasJSON64419C04"
               }
             },
             {
@@ -148,7 +148,7 @@
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SopsComplexSecretJSONFA37D522"
+                "Ref": "SopsComplexSecretJSONAD4C2662"
               }
             },
             {
@@ -158,7 +158,7 @@
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+                "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
               }
             },
             {
@@ -168,7 +168,7 @@
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SopComplexSecretYAMLBAE4AFBC"
+                "Ref": "SopComplexSecretYAMLF52D88F2"
               }
             },
             {
@@ -178,7 +178,7 @@
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SopComplexSecretYAMLFlatC969B78F"
+                "Ref": "SopComplexSecretYAMLFlatD9CE8782"
               }
             },
             {
@@ -188,7 +188,7 @@
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SopsComplexSecretYAMLasJSON9DFE8B13"
+                "Ref": "SopsComplexSecretYAMLasJSONEAE81DB0"
               }
             },
             {
@@ -198,7 +198,7 @@
               ],
               "Effect": "Allow",
               "Resource": {
-                "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+                "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
               }
             }
           ],
@@ -219,7 +219,7 @@
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
           },
-          "S3Key": "934edcf6115b2213914d0b909d6a57615b77497bc80e31d20eff033244b10a83.zip"
+          "S3Key": "8bcfb9be629c18f572586234ab20394a37fd422dc1fb7657730fadbbdf69bc36.zip"
         },
         "Role": {
           "Fn::GetAtt": [
@@ -240,7 +240,7 @@
         "SingletonLambdaSopsSyncProviderServiceRoleC45BBD25"
       ]
     },
-    "SopsSecretYAML311046EA": {
+    "SopsSecretYAMLC392F558": {
       "Type": "AWS::SecretsManager::Secret",
       "Properties": {
         "GenerateSecretString": {}
@@ -258,7 +258,7 @@
           ]
         },
         "SecretARN": {
-          "Ref": "SopsSecretYAML311046EA"
+          "Ref": "SopsSecretYAMLC392F558"
         },
         "SopsS3File": {
           "Bucket": {
@@ -274,7 +274,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "SopsSecretYAMLasJSONE90622C5": {
+    "SopsSecretYAMLasJSON64419C04": {
       "Type": "AWS::SecretsManager::Secret",
       "Properties": {
         "GenerateSecretString": {}
@@ -292,7 +292,7 @@
           ]
         },
         "SecretARN": {
-          "Ref": "SopsSecretYAMLasJSONE90622C5"
+          "Ref": "SopsSecretYAMLasJSON64419C04"
         },
         "SopsS3File": {
           "Bucket": {
@@ -308,7 +308,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "SopsComplexSecretJSONFA37D522": {
+    "SopsComplexSecretJSONAD4C2662": {
       "Type": "AWS::SecretsManager::Secret",
       "Properties": {
         "GenerateSecretString": {}
@@ -326,7 +326,7 @@
           ]
         },
         "SecretARN": {
-          "Ref": "SopsComplexSecretJSONFA37D522"
+          "Ref": "SopsComplexSecretJSONAD4C2662"
         },
         "SopsS3File": {
           "Bucket": {
@@ -342,7 +342,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "SopsComplexSecretJSONFlat34CFF1D0": {
+    "SopsComplexSecretJSONFlatF5FC1D69": {
       "Type": "AWS::SecretsManager::Secret",
       "Properties": {
         "GenerateSecretString": {}
@@ -360,7 +360,7 @@
           ]
         },
         "SecretARN": {
-          "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+          "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
         },
         "SopsS3File": {
           "Bucket": {
@@ -376,7 +376,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "SopComplexSecretYAMLBAE4AFBC": {
+    "SopComplexSecretYAMLF52D88F2": {
       "Type": "AWS::SecretsManager::Secret",
       "Properties": {
         "GenerateSecretString": {}
@@ -394,7 +394,7 @@
           ]
         },
         "SecretARN": {
-          "Ref": "SopComplexSecretYAMLBAE4AFBC"
+          "Ref": "SopComplexSecretYAMLF52D88F2"
         },
         "SopsS3File": {
           "Bucket": {
@@ -410,7 +410,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "SopComplexSecretYAMLFlatC969B78F": {
+    "SopComplexSecretYAMLFlatD9CE8782": {
       "Type": "AWS::SecretsManager::Secret",
       "Properties": {
         "GenerateSecretString": {}
@@ -428,7 +428,7 @@
           ]
         },
         "SecretARN": {
-          "Ref": "SopComplexSecretYAMLFlatC969B78F"
+          "Ref": "SopComplexSecretYAMLFlatD9CE8782"
         },
         "SopsS3File": {
           "Bucket": {
@@ -444,7 +444,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "SopsComplexSecretYAMLasJSON9DFE8B13": {
+    "SopsComplexSecretYAMLasJSONEAE81DB0": {
       "Type": "AWS::SecretsManager::Secret",
       "Properties": {
         "GenerateSecretString": {}
@@ -462,7 +462,7 @@
           ]
         },
         "SecretARN": {
-          "Ref": "SopsComplexSecretYAMLasJSON9DFE8B13"
+          "Ref": "SopsComplexSecretYAMLasJSONEAE81DB0"
         },
         "SopsS3File": {
           "Bucket": {
@@ -478,7 +478,7 @@
       "UpdateReplacePolicy": "Delete",
       "DeletionPolicy": "Delete"
     },
-    "SopsComplexSecretYAMLasJSONFlatAE095DDA": {
+    "SopsComplexSecretYAMLasJSONFlat9FD04B78": {
       "Type": "AWS::SecretsManager::Secret",
       "Properties": {
         "GenerateSecretString": {}
@@ -496,7 +496,7 @@
           ]
         },
         "SecretARN": {
-          "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+          "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
         },
         "SopsS3File": {
           "Bucket": {
@@ -563,7 +563,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+                    "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
                   },
                   ":SecretString:and now.some[0].basic::",
                   {
@@ -582,7 +582,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+                    "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
                   },
                   ":SecretString:and now.some[1].nested::",
                   {
@@ -601,7 +601,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+                    "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
                   },
                   ":SecretString:and now.some[2].type::",
                   {
@@ -620,7 +620,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+                    "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
                   },
                   ":SecretString:and now.some[3].tests::",
                   {
@@ -639,7 +639,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+                    "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
                   },
                   ":SecretString:some.deep.nested.arrays[0]::",
                   {
@@ -658,7 +658,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+                    "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
                   },
                   ":SecretString:some.deep.nested.arrays[1]::",
                   {
@@ -677,7 +677,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+                    "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
                   },
                   ":SecretString:some.deep.nested.arrays[2].values.and::",
                   {
@@ -696,7 +696,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+                    "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
                   },
                   ":SecretString:some.deep.nested.object::",
                   {
@@ -715,7 +715,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretJSONFlat34CFF1D0"
+                    "Ref": "SopsComplexSecretJSONFlatF5FC1D69"
                   },
                   ":SecretString:some.notsodeep::",
                   {
@@ -734,7 +734,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+                    "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
                   },
                   ":SecretString:and now.some[0].basic::",
                   {
@@ -753,7 +753,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+                    "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
                   },
                   ":SecretString:and now.some[1].nested::",
                   {
@@ -772,7 +772,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+                    "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
                   },
                   ":SecretString:and now.some[2].type::",
                   {
@@ -791,7 +791,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+                    "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
                   },
                   ":SecretString:and now.some[3].tests::",
                   {
@@ -810,7 +810,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+                    "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
                   },
                   ":SecretString:some.deep.nested.arrays[0]::",
                   {
@@ -829,7 +829,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+                    "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
                   },
                   ":SecretString:some.deep.nested.arrays[1]::",
                   {
@@ -848,7 +848,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+                    "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
                   },
                   ":SecretString:some.deep.nested.arrays[2].values.and::",
                   {
@@ -867,7 +867,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+                    "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
                   },
                   ":SecretString:some.deep.nested.object::",
                   {
@@ -886,7 +886,7 @@
                 [
                   "{{resolve:secretsmanager:",
                   {
-                    "Ref": "SopsComplexSecretYAMLasJSONFlatAE095DDA"
+                    "Ref": "SopsComplexSecretYAMLasJSONFlat9FD04B78"
                   },
                   ":SecretString:some.notsodeep::",
                   {

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -190,7 +190,7 @@ test('secretValueFromJson(...)', () => {
               [
                 '{{resolve:secretsmanager:',
                 {
-                  Ref: 'SopsSecretBBFD4AF3',
+                  Ref: 'SopsSecretF929FB43',
                 },
                 ':SecretString:test::',
                 {


### PR DESCRIPTION
To ensure the traceability of secret versions and assets, the asset hash (sha256 as hex) without file extension should be used as clientRequestId in the SopsSyncProvider. This way the version corresponds to the asset key used.