### PR TITLE
feat: allow override of asset code path

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,31 @@ Even if this construct has some unit and integration tests performed, there can 
 ### Error getting data key: 0 successful groups required, got 0
 
 This error message (and failed sync) is related to the  mozilla/sops issues [#948](https://github.com/mozilla/sops/issues/948) and [#634](https://github.com/mozilla/sops/issues/634). You must not create your secret with the ```--aws-profile``` flag. This profile will be written to your sops filed and is required in every runtime environment. You have to define the profile to use via the environment variable ```AWS_PROFILE``` instead, to avoid this.
+
+### Asset of sync lambda not found
+
+The lambda asset code is generated relative to the path of the index.ts in this package. With tools like nx this can lead to wrong results, so that the asset could not be found.
+
+You can override the asset path via the [cdk.json](https://docs.aws.amazon.com/cdk/v2/guide/get_context_var.html) or via the flag ```-c```of the cdk cli.
+
+The context used for this override is ```sops_sync_provider_asset_path```.
+
+So for example you can use 
+
+```bash
+cdk deploy -c "sops_sync_provider_asset_path=some/path/asset.zip"
+```
+
+or in your cdk.json
+
+```json
+{
+  "context": {
+    "sops_sync_provider_asset_path": "some/path/asset.zip"
+  } 
+}
+```
+
 ## Motivation
 
 I have created this project to solve a recurring problem of syncing Mozilla/sops secrets into AWS SecretsManager in a convenient, secure way.

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,8 @@ export class SopsSyncProvider extends SingletonFunction implements IGrantable {
   constructor(scope: Construct, id?: string) {
     super(scope, id ?? 'SopsSyncProvider', {
       code: Code.fromAsset(
-        path.join(__dirname, '../assets/cdk-sops-lambda.zip'),
+        scope.node.tryGetContext('sops_sync_provider_asset_path') ||
+          path.join(__dirname, '../assets/cdk-sops-lambda.zip'),
       ),
       runtime: Runtime.GO_1_X,
       handler: 'cdk-sops-secrets',


### PR DESCRIPTION
Fixes incompatibilities with nx - It seams, as if __dirname lookups are not working with nx and lead to wrong results