### PR TITLE
feat: set logRetention only if it is provided, otherwise jsii will print warnings

### DIFF
--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -254,7 +254,9 @@ export class SopsSyncProvider extends SingletonFunction implements IGrantable {
       vpc: props?.vpc,
       vpcSubnets: props?.vpcSubnets,
       securityGroups: props?.securityGroups,
-      logRetention: props?.logRetention,
+      // props.logRetention is deprecated, make sure we only set it if it is actually provided
+      // otherwise jsii will print warnings even for users that don't use this directly
+      ...(props?.logRetention ? { logRetention: props.logRetention } : {}),
       logGroup: props?.logGroup,
     });
     this.sopsAgeKeys = [];


### PR DESCRIPTION
fixes:

```
[WARNING] aws-cdk-lib.aws_lambda.FunctionOptions#logRetention is deprecated.
  use `logGroup` instead
  This API will be removed in the next major release.
```

please check https://github.com/aws/aws-cdk/pull/28783