### PR TITLE
Allow Renovate post-upgrade command jsii-docgen

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,7 @@
     }
   ],
   "postUpdateOptions": ["gomodTidy"],
+  "allowedPostUpgradeCommands": ["mise run jsii-docgen"],
   "postUpgradeTasks": {
     "commands": ["mise run jsii-docgen"],
     "fileFilters": ["package.json", "package-lock.json"],


### PR DESCRIPTION
## Summary
- Allow Renovate to run post-upgrade command `mise run jsii-docgen` via `allowedPostUpgradeCommands`.
- Prevents job failure: command not in allowed list.