### PR TITLE
fix: correct renovate.json configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,7 +34,5 @@
     }
   ],
   "postUpdateOptions": ["gomodTidy"],
-  "gitHubActions": {
-    "pinDigests": true
-  }
+  "pinDigests": true
 }


### PR DESCRIPTION
Replace invalid gitHubActions property with pinDigests at top level