### PR TITLE
chore: upgrade aws-cdk-lib to 2.234.1

### DIFF
--- a/API.md
+++ b/API.md
@@ -62,7 +62,7 @@ Returns a string representation of this construct.
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="cdk-sops-secrets.MultiStringParameter.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="cdk-sops-secrets.MultiStringParameter.isConstruct"></a>
 
 ```typescript
 import { MultiStringParameter } from 'cdk-sops-secrets'
@@ -71,6 +71,20 @@ MultiStringParameter.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdk-sops-secrets.MultiStringParameter.isConstruct.parameter.x"></a>
 
@@ -391,7 +405,7 @@ Interpret the secret as a JSON object and return a field's value from it as a `S
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="cdk-sops-secrets.SopsSecret.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="cdk-sops-secrets.SopsSecret.isConstruct"></a>
 
 ```typescript
 import { SopsSecret } from 'cdk-sops-secrets'
@@ -400,6 +414,20 @@ SopsSecret.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdk-sops-secrets.SopsSecret.isConstruct.parameter.x"></a>
 
@@ -417,6 +445,7 @@ Any object.
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.env">env</a></code> | <code>aws-cdk-lib.interfaces.ResourceEnvironment</code> | The environment this resource belongs to. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.secretArn">secretArn</a></code> | <code>string</code> | The ARN of the secret in AWS Secrets Manager. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.secretName">secretName</a></code> | <code>string</code> | The name of the secret. |
+| <code><a href="#cdk-sops-secrets.SopsSecret.property.secretRef">secretRef</a></code> | <code>aws-cdk-lib.interfaces.aws_secretsmanager.SecretReference</code> | A reference to a Secret resource. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.secretValue">secretValue</a></code> | <code>aws-cdk-lib.SecretValue</code> | Retrieve the value of the stored secret as a `SecretValue`. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
 | <code><a href="#cdk-sops-secrets.SopsSecret.property.sync">sync</a></code> | <code><a href="#cdk-sops-secrets.SopsSync">SopsSync</a></code> | *No description.* |
@@ -484,6 +513,18 @@ The name of the secret.
 
 For "owned" secrets, this will be the full resource name (secret name + suffix), unless the
 '@aws-cdk/aws-secretsmanager:parseOwnedSecretName' feature flag is set.
+
+---
+
+##### `secretRef`<sup>Required</sup> <a name="secretRef" id="cdk-sops-secrets.SopsSecret.property.secretRef"></a>
+
+```typescript
+public readonly secretRef: SecretReference;
+```
+
+- *Type:* aws-cdk-lib.interfaces.aws_secretsmanager.SecretReference
+
+A reference to a Secret resource.
 
 ---
 
@@ -668,7 +709,7 @@ Grants write (PutParameter) permissions on the SSM Parameter.
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="cdk-sops-secrets.SopsStringParameter.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="cdk-sops-secrets.SopsStringParameter.isConstruct"></a>
 
 ```typescript
 import { SopsStringParameter } from 'cdk-sops-secrets'
@@ -677,6 +718,20 @@ SopsStringParameter.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdk-sops-secrets.SopsStringParameter.isConstruct.parameter.x"></a>
 
@@ -892,7 +947,7 @@ Returns a string representation of this construct.
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="cdk-sops-secrets.SopsSync.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="cdk-sops-secrets.SopsSync.isConstruct"></a>
 
 ```typescript
 import { SopsSync } from 'cdk-sops-secrets'
@@ -901,6 +956,20 @@ SopsSync.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdk-sops-secrets.SopsSync.isConstruct.parameter.x"></a>
 
@@ -1461,7 +1530,7 @@ public addAgeKey(key: SecretValue): void
 
 ---
 
-##### ~~`isConstruct`~~ <a name="isConstruct" id="cdk-sops-secrets.SopsSyncProvider.isConstruct"></a>
+##### `isConstruct` <a name="isConstruct" id="cdk-sops-secrets.SopsSyncProvider.isConstruct"></a>
 
 ```typescript
 import { SopsSyncProvider } from 'cdk-sops-secrets'
@@ -1470,6 +1539,20 @@ SopsSyncProvider.isConstruct(x: any)
 ```
 
 Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
 
 ###### `x`<sup>Required</sup> <a name="x" id="cdk-sops-secrets.SopsSyncProvider.isConstruct.parameter.x"></a>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
         "@types/node": "^24.10.3",
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
-        "aws-cdk": "^2",
-        "aws-cdk-lib": "2.233.0",
+        "aws-cdk": "^2.1100.3",
+        "aws-cdk-lib": "2.234.1",
         "commit-and-tag-version": "^12.4.4",
         "constructs": "10.4.4",
         "eslint": "^9",
@@ -74,9 +74,9 @@
       "license": "MIT"
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.242",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
-      "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
+      "version": "2.2.258",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.258.tgz",
+      "integrity": "sha512-TL3I9cIue0bAsuwrmjgjAQaEH6JL09y49FVQMDhrz4jJ2iPKuHtdrYd7ydm02t1YZdPZE2M0VNj6VD4fGIFpvw==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -145,7 +145,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -339,7 +338,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2037,7 +2035,6 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2108,7 +2105,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2599,7 +2595,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6682,9 +6677,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.233.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.233.0.tgz",
-      "integrity": "sha512-rBOzIA8TGC5eB8TyVIvckAVlX7a0/gVPE634FguhSee9RFaovjgc5+IixGyyLJhu3lLsMSjqDoqTJg2ab+p8ng==",
+      "version": "2.234.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.234.1.tgz",
+      "integrity": "sha512-2oNqAA1qjF9xHCom6yHuY8KE6UltK7pTg3egf/t1+C6/OFEaw9+jyhCWmTasGmvjyQSkbvKiCPZco0l+XVyxiQ==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -6701,12 +6696,12 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.242",
+        "@aws-cdk/asset-awscli-v1": "2.2.258",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
         "@aws-cdk/cloud-assembly-schema": "^48.20.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.2",
+        "fs-extra": "^11.3.3",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
@@ -6856,7 +6851,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.2",
+      "version": "11.3.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7658,8 +7653,7 @@
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.4.tgz",
       "integrity": "sha512-lP0qC1oViYf1cutHo9/KQ8QL637f/W29tDmv/6sy35F5zs+MD9f66nbAAIjicwc7fwyuF3rkg6PhZh4sfvWIpA==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/conventional-changelog": {
       "version": "4.0.0",
@@ -8859,7 +8853,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8920,7 +8913,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9047,7 +9039,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10629,7 +10620,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -12067,7 +12057,6 @@
       "integrity": "sha512-Q1Uu7S0kBUiuhRKzjw7VLgiJ31PdlH2e/nFZbfJQeUU7hFpmswltWUoWxMNoWXWi6JnN580VnJm54/ZDE4hQeg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@jsii/check-node": "^1.124.0",
         "@jsii/spec": "^1.124.0",
@@ -14888,7 +14877,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15972,7 +15960,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16092,7 +16079,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16237,7 +16223,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16308,7 +16293,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "aws-cdk": "^2.1100.3",
-    "aws-cdk-lib": "2.233.0",
+    "aws-cdk-lib": "2.234.1",
     "commit-and-tag-version": "^12.4.4",
     "constructs": "10.4.4",
     "eslint": "^9",

--- a/src/SopsSecret.ts
+++ b/src/SopsSecret.ts
@@ -13,6 +13,7 @@ import {
   RotationScheduleOptions,
   Secret,
   SecretProps,
+  SecretReference,
 } from 'aws-cdk-lib/aws-secretsmanager';
 import {
   RemovalPolicy,
@@ -87,6 +88,7 @@ export class SopsSecret extends Construct implements ISecret {
   readonly secretArn: string;
   readonly secretFullArn?: string | undefined;
   readonly secretName: string;
+  readonly secretRef: SecretReference;
   readonly stack: Stack;
   readonly env: ResourceEnvironment;
 
@@ -99,6 +101,7 @@ export class SopsSecret extends Construct implements ISecret {
     this.encryptionKey = this.secret.encryptionKey;
     this.secretArn = this.secret.secretArn;
     this.secretName = this.secret.secretName;
+    this.secretRef = this.secret.secretRef;
     this.stack = Stack.of(scope);
     this.env = {
       account: this.stack.account,


### PR DESCRIPTION
Heya, first-time contributor here 👋  Feel free to let me know if I missed something.

This PR upgrades aws-cdk-lib to 2.234.1 and adds support for it by adding the `secretRef` property to the `SopsSecret` class.