### PR TITLE
fix: update release workflow to respect branch protection

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   actions: write
+  pull-requests: write
 
 jobs:
   release:
@@ -55,12 +56,27 @@ jobs:
 
           echo "Prepared release $NEW_TAG"
 
-      - name: Push changes and tag
+      - name: Create release branch and PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Push the version bump commit and tag
-          git push --follow-tags origin main
+          # Create and push release branch (without tag)
+          BRANCH_NAME="release/${{ steps.version.outputs.new_tag }}"
+          git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME"
+          
+          # Create pull request with tag info in body
+          echo "## Release ${{ steps.version.outputs.new_tag }}" > /tmp/pr_body.md
+          echo "" >> /tmp/pr_body.md
+          echo "This PR will create tag \`${{ steps.version.outputs.new_tag }}\` when merged." >> /tmp/pr_body.md
+          echo "" >> /tmp/pr_body.md
+          cat /tmp/release_notes.md >> /tmp/pr_body.md
+          
+          gh pr create \
+            --title "Release ${{ steps.version.outputs.new_tag }}" \
+            --body-file /tmp/pr_body.md \
+            --base main \
+            --head "$BRANCH_NAME"
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Create and push release branch (without tag)
+          # Create and push release branch (local tag not pushed)
           BRANCH_NAME="release/${{ steps.version.outputs.new_tag }}"
           git checkout -b "$BRANCH_NAME"
           git push origin "$BRANCH_NAME"

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   actions: write
+  pull-requests: read
 
 jobs:
   create-tag-and-release:

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -31,11 +31,14 @@ jobs:
       - name: Create and push tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use the PR head SHA so the tag points to the actual release commit,
+          # not the merge commit on main.
+          RELEASE_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           
-          git tag ${{ steps.version.outputs.version }}
+          git tag ${{ steps.version.outputs.version }} $RELEASE_SHA
           git push origin ${{ steps.version.outputs.version }}
 
       - name: Extract changelog for release

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Extract version from branch name

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,0 +1,57 @@
+name: tag-on-merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  create-tag-and-release:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          git tag ${{ steps.version.outputs.version }}
+          git push origin ${{ steps.version.outputs.version }}
+
+      - name: Extract changelog for release
+        run: |
+          # Extract changelog content for this version
+          CHANGELOG_CONTENT=$(awk '/^## \[/{if(++count==2) exit; if(count==1) next} count==1' CHANGELOG.md)
+          echo "$CHANGELOG_CONTENT" > /tmp/release_notes.md
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ steps.version.outputs.version }} \
+            --title "${{ steps.version.outputs.version }}" \
+            --notes-file /tmp/release_notes.md
+
+      - name: Trigger release workflow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml --ref ${{ steps.version.outputs.version }}


### PR DESCRIPTION
Updates the release workflow to work with branch protection rules:

- Modify create-release workflow to create PR instead of direct push to main
- Add tag-on-merge workflow to create tags when release PRs are merged
- Ensures release process works with branch protection rules

This fixes the issue where the create-release workflow was failing due to protected branch restrictions.