### PR TITLE
feat: Lambda runtime upgrade to AL2023

### DIFF
--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -238,7 +238,7 @@ export class SopsSyncProvider extends SingletonFunction implements IGrantable {
         scope.node.tryGetContext('sops_sync_provider_asset_path') ||
           path.join(__dirname, '../assets/cdk-sops-lambda.zip'),
       ),
-      runtime: Runtime.PROVIDED_AL2,
+      runtime: Runtime.PROVIDED_AL2023,
       handler: 'bootstrap',
       uuid: props?.uuid ?? 'SopsSyncProvider',
       role: props?.role,

--- a/test/__snapshots__/PARAMETER.integ.snapshot.json
+++ b/test/__snapshots__/PARAMETER.integ.snapshot.json
@@ -153,7 +153,7 @@
       "Arn"
      ]
     },
-    "Runtime": "provided.al2",
+    "Runtime": "provided.al2023",
     "Timeout": 60
    },
    "DependsOn": [

--- a/test/__snapshots__/PARAMETER_MULTI.integ.snapshot.json
+++ b/test/__snapshots__/PARAMETER_MULTI.integ.snapshot.json
@@ -549,7 +549,7 @@
       "Arn"
      ]
     },
-    "Runtime": "provided.al2",
+    "Runtime": "provided.al2023",
     "Timeout": 60
    },
    "DependsOn": [

--- a/test/__snapshots__/SECRET.integ.snapshot.json
+++ b/test/__snapshots__/SECRET.integ.snapshot.json
@@ -188,7 +188,7 @@
       "Arn"
      ]
     },
-    "Runtime": "provided.al2",
+    "Runtime": "provided.al2023",
     "Timeout": 60
    },
    "DependsOn": [


### PR DESCRIPTION
This restores the changes from PR #1215 that were lost when we rewrote Git history to remove .DS_Store files.

Original PR: #1215
- feat: upgrade Lambda runtime from Amazon Linux 2 to Amazon Linux 2023

Cherry-picked from commit 6f511f06139e1cd1714dff23f20122ac6590ed3a