### PR TITLE
chore: tag releases on merge commit

### DIFF
--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -31,14 +31,11 @@ jobs:
       - name: Create and push tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Use the PR head SHA so the tag points to the actual release commit,
-          # not the merge commit on main.
-          RELEASE_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          
-          git tag ${{ steps.version.outputs.version }} $RELEASE_SHA
+
+          git tag ${{ steps.version.outputs.version }}
           git push origin ${{ steps.version.outputs.version }}
 
       - name: Extract changelog for release


### PR DESCRIPTION
## Summary
- tag release versions on the main merge commit so release tags stay reachable from main
- fixes changelog generation by letting commit-and-tag-version find the latest tag
