### PR TITLE
chore: bump go toolchain to 1.25.6

### DIFF
--- a/lambda/go.mod
+++ b/lambda/go.mod
@@ -1,6 +1,6 @@
 module github.com/markussiebert/cdk-sops-secrets
 
-go 1.25.4
+go 1.25.6
 
 require (
 	github.com/aws/aws-lambda-go v1.50.0

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@
 CDK_DISABLE_CLI_TELEMETRY = "true"
 
 [tools]
-golang = "1.25.4"
+golang = "1.25.6"
 nodejs = "24.11.1"
 grype = "0.104.1"
 python = "3.14.0"


### PR DESCRIPTION
## Summary
- update Go toolchain version in mise and lambda module
- align release tooling with Go 1.25.6 to address stdlib CVE fixes
