### PR TITLE
chore: Update Go version in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@
 CDK_DISABLE_CLI_TELEMETRY = "true"
 
 [tools]
-golang = "1.25.7"
+golang = "1.26"
 nodejs = "24.11.1"
 grype = "0.104.1"
 python = "3.14.0"


### PR DESCRIPTION
Upgrade Go version from 1.25.7 to 1.26 in mise.toml

Fixes #