### PR TITLE
chore: add allowedPostUpgradeCommands to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "enabledManagers": ["gomod", "npm", "mise", "github-actions"],
+  "allowedPostUpgradeCommands": [
+    "^npm ci$",
+    "^npx jsii --silence-warnings=reserved-word$",
+    "^npx jsii-docgen -o API\\.md$"
+  ],
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
Fixes Renovate artifact update problem by adding the required post-upgrade commands to the allowed list.

This allows Renovate to run:
- `npm ci`
- `npx jsii --silence-warnings=reserved-word`
- `npx jsii-docgen -o API.md`

These commands are already configured in `postUpgradeTasks` but need to be explicitly allowed for security reasons.