### PR TITLE
fix: remove dangerous workflow patterns

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Install mise
         uses: jdx/mise-action@e79ddf65a11cec7b0e882bedced08d6e976efb2d # v3

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -16,7 +16,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      pull-requests: read
     if: github.event_name == 'pull_request'
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -2,7 +2,7 @@
 
 name: pull-request-lint
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
       - opened
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
+    if: github.event_name == 'pull_request'
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -23,8 +23,9 @@ jobs:
 
       - name: Extract version from branch name
         id: version
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
           VERSION=${BRANCH_NAME#release/}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Changes
This PR fixes dangerous workflow patterns detected by OSS Scorecard.

### Security Fixes:
1. **pull-request-lint.yml**: Changed `pull_request_target` to `pull_request`
   - `pull_request_target` runs with write permissions in base repo context, even for fork PRs
   - This creates risk of secret exfiltration and unauthorized access
   - `pull_request` is sufficient for PR title validation

2. **build.yml**: Removed explicit checkout of untrusted PR code
   - Removed `ref` and `repository` parameters that explicitly checked out fork code
   - Default checkout behavior is safer for pull_request trigger

## Impact
- Reduces attack surface for malicious PRs from forks
- Maintains all existing functionality
- No breaking changes

Fixes GHSA-wr66-jh8v-93x5