### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS
+# These owners will be requested for review when someone opens a pull request.
+# See MAINTAINERS.md for the full list of maintainers.
+
+* @dariozachow @henrysachs @lenderom @markussiebert @obirah


### PR DESCRIPTION
## Changes
Add CODEOWNERS file to enable code owner review requirements in branch protection.

### Details:
- All maintainers from MAINTAINERS.md are set as default code owners
- Code owners will be automatically requested for review on all PRs
- Improves branch protection security posture

### Impact:
- Branch Protection score improvement (8/10 → closer to 10/10)
- Ensures maintainer oversight on all changes
- Aligns with OSS Scorecard best practices

Addresses GHSA-7g25-q9hm-ppj3