### PR TITLE
chore: simplify public disclosure section in security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -25,4 +25,4 @@ We use [Renovate](https://github.com/renovatebot/renovate) to automatically keep
 
 ## Public Disclosure
 
-We kindly request you avoid public disclosure until a fix is available. We will coordinate a [CVE](https://www.cve.org/) if appropriate and credit reporters in release notes (unless anonymity is requested).
+We kindly request you avoid public disclosure until a fix is available. We will coordinate a [CVE](https://www.cve.org/) if appropriate.


### PR DESCRIPTION
## Changes
Simplify the Public Disclosure section in SECURITY.md to keep it neutral and unambiguous.

### What Changed:
Removed the mention of "crediting reporters in release notes" to avoid any potential misinterpretation about compensation or rewards.

### New Text:
Simply states we request coordinated disclosure and will coordinate CVE if appropriate.

This keeps the policy clear and professional without any ambiguity.