### PR TITLE
chore: Updating dependency yaml because of  CVE-2026-33532

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "yaml": "^2.8.1"
+        "yaml": "^2.8.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "constructs": "^10.0.5"
   },
   "dependencies": {
-    "yaml": "^2.8.1"
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",


### PR DESCRIPTION
Ref: https://github.com/advisories/GHSA-48c2-rrv3-qjmp

Since the dependency is added a bundled dependency it is not possible for downstream projects to even override the dependency.

Fixes #
Updated the yaml version