### PR TITLE
fix(renovate): disable major updates for indirect Go deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,12 @@
       "automerge": true
     },
     {
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "groupName": "npm-deps",
       "automerge": true
@@ -25,6 +31,6 @@
       "automerge": true
     }
   ],
-  "postUpdateOptions": ["gomodTidy"],
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "pinDigests": true
 }


### PR DESCRIPTION
## Problem

PR #1307 (Renovate major Go deps update) fails the build because Go major version updates change module import paths (e.g. `v1` → `v2`). Indirect dependencies cannot be updated independently — the parent module (e.g. sops) still imports the old paths, so `go mod tidy` removes the unused new entries, failing the verify step.

## Changes

- **Disable major updates for indirect Go deps** — these can never work automatically since the importing module needs to update first
- **Add `gomodUpdateImportPaths`** — so direct major updates get their source import paths updated automatically by Renovate

## Closes

Closes #1307