### PR TITLE
chore: make chore commits visible in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,7 +13,7 @@
     {"type": "deps", "section": "Dependencies", "hidden": false},
     {"type": "revert", "section": "Reverts", "hidden": false},
     {"type": "docs", "section": "Documentation", "hidden": false},
-    {"type": "chore", "section": "Miscellaneous Chores", "hidden": true},
+    {"type": "chore", "section": "Miscellaneous Chores", "hidden": false},
     {"type": "refactor", "section": "Code Refactoring", "hidden": true},
     {"type": "test", "section": "Tests", "hidden": true},
     {"type": "build", "section": "Build System", "hidden": true},


### PR DESCRIPTION
Sets `chore` type to `hidden: false` so chore commits (like dependency updates) trigger release PRs.