### PR TITLE
chore: sync min-release-age to 1 days (renovate + npmrc)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 ignore-scripts=true
-min-release-age=5
+min-release-age=1
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "rebaseWhen": "behind-base-branch",
+  "minimumReleaseAge": "1 day",
   "enabledManagers": ["gomod", "npm", "mise", "github-actions"],
 
   "packageRules": [


### PR DESCRIPTION
Syncs `minimumReleaseAge: 1 days` in Renovate with `min-release-age=1` in .npmrc. Prevents Renovate from proposing packages that npm ci would reject.