### PR TITLE
chore: attach SLSA provenance to GitHub Release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   build_publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
       attestations: write
     env:
@@ -55,6 +55,18 @@ jobs:
         uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
           subject-path: 'dist/**/*.tgz,dist/**/*.jar,dist/**/*.whl,dist/**/*.nupkg,dist/**/*.zip'
+
+      - name: Attach provenance to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation download --repo "$GITHUB_REPOSITORY" --digest-algorithm sha256 \
+            --format json --output provenance.intoto.jsonl \
+            "$(find dist -name '*.tgz' | head -1)" || true
+          if [ -f provenance.intoto.jsonl ]; then
+            gh release upload "${{ github.event.release.tag_name }}" provenance.intoto.jsonl --clobber
+          fi
 
   publish_npm:
     name: Publish to npm


### PR DESCRIPTION
Attaches `provenance.intoto.jsonl` to GitHub Release assets after attestation. Scorecard Signed-Releases check requires this file in release assets for 10/10.