### PR TITLE
chore: add top-level permissions to update-jsii-artifacts workflow

### DIFF
--- a/.github/workflows/update-jsii-artifacts.yml
+++ b/.github/workflows/update-jsii-artifacts.yml
@@ -3,6 +3,8 @@ name: Update JSII Artifacts
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   update:
     if: github.event.pull_request.user.login == 'renovate[bot]' || github.actor == 'renovate[bot]'


### PR DESCRIPTION
Adds `permissions: {}` at top level. Fixes Scorecard Token-Permissions warning.