### PR TITLE
fix: resolve CodeQL incomplete string escaping alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![pypi](https://img.shields.io/pypi/v/cdk-sops-secrets.svg)](https://pypi.org/project/cdk-sops-secrets)
 [![pypi downloads](https://img.shields.io/pypi/dw/cdk-sops-secrets)](https://pypi.org/project/cdk-sops-secrets)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/dbsystel/cdk-sops-secrets/badge)](https://scorecard.dev/viewer/?uri=github.com/dbsystel/cdk-sops-secrets)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12072/badge)](https://www.bestpractices.dev/projects/12072)
 
 # Introduction
 

--- a/src/MultiStringParameter.ts
+++ b/src/MultiStringParameter.ts
@@ -47,9 +47,9 @@ export class MultiStringParameter extends Construct {
     const keys = this.parseFile(props.sopsFilePath!, this.keySeparator)
       .filter((key) => !key.startsWith('sops'))
       .map((value) => {
-        // Ass we flatten array to [number] path notations, we have to fix this for parameter store
-        let fixedKey = value.replace('[', this.keySeparator);
-        fixedKey = fixedKey.replace(']', this.keySeparator);
+        // As we flatten array to [number] path notations, we have to fix this for parameter store
+        let fixedKey = value.replace(/\[/g, this.keySeparator);
+        fixedKey = fixedKey.replace(/\]/g, this.keySeparator);
         if (fixedKey.endsWith(this.keySeparator)) {
           fixedKey = fixedKey.slice(0, -1);
         }


### PR DESCRIPTION
## Summary

Fix two High-severity CodeQL alerts ('Incomplete string escaping or encoding') in `src/MultiStringParameter.ts`.

## Changes

Replace first-occurrence-only `.replace('[', ...)` / `.replace(']', ...)` with global regex `.replace(/\[/g, ...)` / `.replace(/\]/g, ...)` to correctly handle all bracket occurrences in parameter path keys.

## What was tested

- `mise run build` passes (excluding java packaging — local env issue)
- Jest: 51 tests pass, 84.77% branch coverage
- TypeScript compiles clean (`tsc --noEmit`)