### PR TITLE
fix(ci): address zizmor security findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install mise
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           client-id: ${{ secrets.RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.RELEASER_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set git identity
         run: |
@@ -36,6 +37,7 @@ jobs:
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
         with:
           experimental: true
+          cache: false
 
       - name: Build / prepare dist
         run: mise run build
@@ -60,13 +62,14 @@ jobs:
         if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           ARTIFACT="$(find dist -name '*.tgz' | head -1)"
           gh attestation download "$ARTIFACT" --repo "$GITHUB_REPOSITORY" || true
           JSONL=$(find . -maxdepth 1 -name "sha256*.jsonl" | head -1)
           if [ -n "$JSONL" ]; then
             mv "$JSONL" provenance.intoto.jsonl
-            gh release upload "${{ github.event.release.tag_name }}" provenance.intoto.jsonl --clobber
+            gh release upload "$TAG_NAME" provenance.intoto.jsonl --clobber
           fi
 
   publish_npm:
@@ -92,6 +95,7 @@ jobs:
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Release
         env:
@@ -111,6 +115,8 @@ jobs:
     steps:
       - name: Install mise
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
+        with:
+          cache: false
 
       - name: Download build artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
@@ -152,6 +158,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 'lts/*'
+          package-manager-cache: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
@@ -173,6 +180,8 @@ jobs:
     steps:
       - name: Install mise
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
+        with:
+          cache: false
 
       - name: Download build artifacts
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6

--- a/.github/workflows/update-jsii-artifacts.yml
+++ b/.github/workflows/update-jsii-artifacts.yml
@@ -7,7 +7,7 @@ permissions: {}
 
 jobs:
   update:
-    if: github.event.pull_request.user.login == 'renovate[bot]' || github.actor == 'renovate[bot]'
+    if: github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,23 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## Summary

Address security findings reported by [zizmor](https://zizmor.sh/) static analysis for GitHub Actions workflows.

## Changes

**Fixes applied:**
- **template-injection** (`release.yml`): Moved `github.event.release.tag_name` from inline `${{ }}` expansion to env var to prevent code injection
- **github-app** (`release-please.yml`): Scoped app token permissions (`permission-contents: write`, `permission-pull-requests: write`) instead of blanket installation permissions
- **artipacked** (`build.yml`, `release.yml`): Added `persist-credentials: false` to checkout steps
- **cache-poisoning** (`release.yml`): Disabled caching on `mise-action` (×3) and `setup-node` (×2) in release workflow to prevent cache poisoning on publish triggers
- **bot-conditions** (`update-jsii-artifacts.yml`): Removed spoofable `github.actor` check, keeping only `github.event.pull_request.user.login`

**New workflow:**
- Added `zizmor.yml` workflow for continuous GitHub Actions security analysis via GitHub Advanced Security (SARIF upload)

## Remaining

1 low-confidence `artipacked` warning on `update-jsii-artifacts.yml` — intentionally accepted since the workflow requires persisted credentials for `git push`.

## Testing

- Ran `zizmor .github/workflows/` locally: 0 high findings, 1 medium (accepted)
