### PR TITLE
fix(SopsSecret): grant kms:Decrypt on grantRead for imported keys

### DIFF
--- a/src/SopsSecret.ts
+++ b/src/SopsSecret.ts
@@ -7,7 +7,7 @@ import {
   Role,
   ServicePrincipal,
 } from 'aws-cdk-lib/aws-iam';
-import { IKey, ViaServicePrincipal } from 'aws-cdk-lib/aws-kms';
+import { IKey } from 'aws-cdk-lib/aws-kms';
 import { CfnSchedule, CfnScheduleGroup } from 'aws-cdk-lib/aws-scheduler';
 import {
   ISecret,
@@ -525,13 +525,22 @@ export class SopsSecret extends Construct implements ISecret {
 
   public grantRead(grantee: IGrantable, versionStages?: string[]): Grant {
     if (this.encryptionKey) {
+      // Grant kms:Decrypt directly to the grantee's identity policy, restricted
+      // to access via SecretsManager. Granting to a ViaServicePrincipal wrapper
+      // instead silently drops the statement for imported keys, because the
+      // wrapper cannot carry an identity policy and an imported key has no
+      // modifiable key policy.
       // @see https://docs.aws.amazon.com/kms/latest/developerguide/services-secrets-manager.html
-      this.encryptionKey.grantDecrypt(
-        new ViaServicePrincipal(
-          `secretsmanager.${Stack.of(this).region}.amazonaws.com`,
-          grantee.grantPrincipal,
-        ),
-      );
+      Grant.addToPrincipal({
+        grantee,
+        actions: ['kms:Decrypt'],
+        resourceArns: [this.encryptionKey.keyArn],
+        conditions: {
+          StringEquals: {
+            'kms:ViaService': `secretsmanager.${Stack.of(this).region}.amazonaws.com`,
+          },
+        },
+      });
     }
     return this.secret.grantRead(grantee, versionStages);
   }

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -1542,3 +1542,51 @@ test('Expiration enabled - raw binary output is rejected', () => {
     'Expiration scheduling does not support rawOutput. Remove rawOutput to use expirationNotification.',
   );
 });
+
+test('grantRead adds kms:Decrypt to grantee for an imported encryptionKey (issue #1398)', () => {
+  const app = new App();
+  const stack = new Stack(app, 'SecretIntegration', {
+    env: { account: '111122223333', region: 'us-west-2' },
+  });
+
+  const key = Key.fromKeyArn(
+    stack,
+    'EncryptionKey',
+    'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab',
+  );
+
+  const secret = new SopsSecret(stack, 'SopsSecret', {
+    sopsFilePath: 'test-secrets/json/sopsfile.enc-age.json',
+    encryptionKey: key,
+    sopsKmsKey: [key],
+  });
+
+  const role = new Role(stack, 'TestRole', {
+    roleName: 'GrantReadImportedKeyRole',
+    assumedBy: new ServicePrincipal('ecs-tasks.amazonaws.com'),
+  });
+
+  secret.grantRead(role);
+
+  // The grantee's identity policy must carry kms:Decrypt on the imported key,
+  // restricted to access via SecretsManager. Prior to the fix this statement
+  // was silently dropped for imported keys.
+  Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+    PolicyDocument: Match.objectLike({
+      Statement: Match.arrayWith([
+        {
+          Action: 'kms:Decrypt',
+          Effect: 'Allow',
+          Resource:
+            'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab',
+          Condition: {
+            StringEquals: {
+              'kms:ViaService': 'secretsmanager.us-west-2.amazonaws.com',
+            },
+          },
+        },
+      ]),
+    }),
+    Roles: [{ Ref: 'TestRole6C9272DF' }],
+  });
+});


### PR DESCRIPTION
## Summary

`SopsSecret.grantRead` silently dropped the `kms:Decrypt` grant when `encryptionKey` was an **imported** key (`kms.Key.fromKeyArn(...)`). Synth succeeded with no KMS statement for the grantee, and the failure only surfaced at runtime (e.g. ECS-native secret injection failing with `AccessDeniedException: Access to KMS is not allowed`).

Fixes #1398.

## Root cause

`grantRead` wrapped the grantee in a `ViaServicePrincipal` before calling `encryptionKey.grantDecrypt`. `grantDecrypt` routes through `Grant.addToPrincipalOrResource`, and both paths are dead ends for an imported key:

1. **Principal path:** `ViaServicePrincipal extends PrincipalBase`, whose `addToPrincipalPolicy` returns `{ statementAdded: false }` — the wrapper cannot carry an identity policy even when the wrapped principal (a role) could.
2. **Resource path:** an imported key has no modifiable key policy, so `addToResourcePolicy` is a no-op.

The grant landed nowhere, with no error or synth warning. For owned keys the resource path succeeds, which is why the bug was masked. `SopsStringParameter.grantRead` was never affected because it grants to the grantee directly.

## Fix

Grant `kms:Decrypt` directly to the grantee's identity policy and express the via-service restriction as a `kms:ViaService` condition instead of a wrapper principal:

```ts
Grant.addToPrincipal({
  grantee,
  actions: ['kms:Decrypt'],
  resourceArns: [this.encryptionKey.keyArn],
  conditions: {
    StringEquals: {
      'kms:ViaService': `secretsmanager.${Stack.of(this).region}.amazonaws.com`,
    },
  },
});
```

This works for both owned and imported keys whenever the grantee has an attachable identity policy (the common case: Lambda/ECS execution roles), keeps the via-service restriction, and matches what `SopsStringParameter.grantRead` already does.

### Notes / considerations

- **Behavior change for owned keys:** the statement now lands on the grantee's identity policy instead of the key resource policy. This is a benign template diff on next deploy for existing owned-key users. Identity-policy grants also scale better than key-policy grants (the key policy has a hard 32KB limit).
- **No duplicate statements:** verified that a grantee reading multiple secrets that share a key ends up with a single merged `kms:Decrypt` statement (CDK `minimizePolicies`, default-on in v2).
- A type-based conditional (imported vs owned) was considered but rejected: CDK exposes no public API to detect an imported `IKey`, and the uniform approach is correct for both.

## Testing

- Added a regression test: imported key + `grantRead(role)` asserts the grantee policy carries `kms:Decrypt` on the key with the `kms:ViaService` condition. Confirmed it fails without the src change and passes with it.
- Full `test/secret.test.ts` suite passes (47/47). eslint and prettier clean.
